### PR TITLE
Added support for backups with multiple databaes files

### DIFF
--- a/Scripts/2.FindLogicalPaths.sql
+++ b/Scripts/2.FindLogicalPaths.sql
@@ -6,18 +6,15 @@ DECLARE @LogicalLogFileName NVARCHAR(128); -- Declare a variable to hold the log
 
 -- Get logical file names
 SELECT 
-    @LogicalDataFileName = df.name
+    LogicalDataFileName = df.name
 FROM 
     sys.database_files df
 WHERE 
     df.type = 0; -- Data file
 
 SELECT 
-    @LogicalLogFileName = df.name
+    LogicalLogFileName = df.name
 FROM 
     sys.database_files df
 WHERE 
     df.type = 1; -- Log file
-
--- Verify the logical file names
-SELECT @LogicalDataFileName AS LogicalDataFileName, @LogicalLogFileName AS LogicalLogFileName; -- Display the logical data and log file names


### PR DESCRIPTION
The original script didn't support backup files, which contains multiple database files, and that meant, it gets complicated and requires manual work to test Flyway with your own company databases

This PR will solve that issue, as you can just add more logical filenames to some temporary tables